### PR TITLE
Add WebSprix telephony integration

### DIFF
--- a/crm/fcrm/doctype/crm_websprix_settings/__init__.py
+++ b/crm/fcrm/doctype/crm_websprix_settings/__init__.py
@@ -1,0 +1,1 @@
+# Placeholder

--- a/crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.json
+++ b/crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.json
@@ -1,0 +1,11 @@
+{
+  "doctype": "DocType",
+  "issingle": 1,
+  "module": "FCRM",
+  "field_order": ["enabled", "base_url", "webhook_verify_token"],
+  "fields": [
+    {"fieldname": "enabled", "fieldtype": "Check", "label": "Enabled", "default": "0"},
+    {"fieldname": "base_url", "fieldtype": "Data", "label": "Base URL", "depends_on": "enabled"},
+    {"fieldname": "webhook_verify_token", "fieldtype": "Data", "label": "Webhook Verify Token", "depends_on": "enabled"}
+  ]
+}

--- a/crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.py
+++ b/crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.py
@@ -1,0 +1,6 @@
+import frappe
+from frappe.model.document import Document
+
+
+class CRMWebSprixSettings(Document):
+pass

--- a/crm/fcrm/doctype/crm_websprix_settings/test_crm_websprix_settings.py
+++ b/crm/fcrm/doctype/crm_websprix_settings/test_crm_websprix_settings.py
@@ -1,0 +1,13 @@
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+
+class UnitTestCRMWebSprixSettings(UnitTestCase):
+"""Unit tests for CRMWebSprixSettings."""
+
+pass
+
+
+class IntegrationTestCRMWebSprixSettings(IntegrationTestCase):
+"""Integration tests for CRMWebSprixSettings."""
+
+pass

--- a/crm/integrations/api.py
+++ b/crm/integrations/api.py
@@ -10,11 +10,13 @@ def is_call_integration_enabled():
 	twilio_enabled = frappe.db.get_single_value("CRM Twilio Settings", "enabled")
 	exotel_enabled = frappe.db.get_single_value("CRM Exotel Settings", "enabled")
 	plivo_enabled = frappe.db.get_single_value("CRM Plivo Settings", "enabled")
+	websprix_enabled = frappe.db.get_single_value("CRM WebSprix Settings", "enabled")
 
 	return {
 	"twilio_enabled": twilio_enabled,
 	"exotel_enabled": exotel_enabled,
 	"plivo_enabled": plivo_enabled,
+	"websprix_enabled": websprix_enabled,
 	"default_calling_medium": get_user_default_calling_medium(),
 	}
 

--- a/crm/integrations/websprix/handler.py
+++ b/crm/integrations/websprix/handler.py
@@ -1,0 +1,212 @@
+import bleach
+import frappe
+import requests
+from frappe import _
+from frappe.integrations.utils import create_request_log
+
+from crm.integrations.api import get_contact_by_phone_number
+
+
+@frappe.whitelist(allow_guest=True)
+def handle_request(**kwargs):
+    """Handle incoming requests from WebSprix."""
+    validate_request()
+    if not is_integration_enabled():
+        return
+
+    request_log = create_request_log(
+        kwargs,
+        request_description="WebSprix Call",
+        service_name="WebSprix",
+        request_headers=frappe.request.headers,
+        is_remote_request=1,
+    )
+
+    try:
+        request_log.status = "Completed"
+        settings = get_websprix_settings()
+        if not settings.enabled:
+            return
+
+        call_payload = kwargs
+
+        frappe.publish_realtime("websprix_call", call_payload)
+        status = call_payload.get("status")
+        if status == "free":
+            return
+
+        if call_log := get_call_log(call_payload):
+            update_call_log(call_payload, call_log=call_log)
+        else:
+            create_call_log(
+                call_id=call_payload.get("call_id"),
+                from_number=call_payload.get("from"),
+                to_number=call_payload.get("to"),
+                medium="WebSprix",
+                status=get_call_log_status(call_payload),
+                agent=call_payload.get("agent"),
+            )
+    except Exception:
+        request_log.status = "Failed"
+        request_log.error = frappe.get_traceback()
+        frappe.db.rollback()
+        frappe.log_error(title="Error while creating/updating call record")
+        frappe.db.commit()
+    finally:
+        request_log.save(ignore_permissions=True)
+        frappe.db.commit()
+
+
+@frappe.whitelist()
+def make_a_call(to_number, from_number=None):
+    if not is_integration_enabled():
+        frappe.throw(_("Please setup WebSprix integration"), title=_("Integration Not Enabled"))
+
+    endpoint = get_websprix_endpoint("call")
+
+    if not from_number:
+        from_number = frappe.get_value("CRM Telephony Agent", {"user": frappe.session.user}, "mobile_no")
+
+    if not from_number:
+        frappe.throw(
+            _("You do not have mobile number set in your Telephony Agent"), title=_("Mobile Number Missing")
+        )
+
+    try:
+        response = requests.post(
+            endpoint,
+            json={"from": from_number, "to": to_number},
+        )
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        if exc := response.json().get("error"):
+            frappe.throw(bleach.linkify(exc), title=_("WebSprix Exception"))
+    else:
+        res = response.json()
+        call_payload = res.get("call", {})
+        create_call_log(
+            call_id=call_payload.get("id"),
+            from_number=from_number,
+            to_number=to_number,
+            medium="WebSprix",
+            call_type="Outgoing",
+            agent=frappe.session.user,
+        )
+
+    call_details = response.json()
+    call_details["call_id"] = call_details.get("id", "")
+    return call_details
+
+
+def get_websprix_endpoint(action=None):
+    settings = get_websprix_settings()
+    base = settings.base_url.rstrip("/") + "/api/"
+    if action:
+        base += action
+    return base
+
+
+def get_websprix_settings():
+    return frappe.get_single("CRM WebSprix Settings")
+
+
+@frappe.whitelist(allow_guest=True)
+def is_integration_enabled():
+    return frappe.db.get_single_value("CRM WebSprix Settings", "enabled", True)
+
+
+# Call Log Functions
+def create_call_log(
+    call_id,
+    from_number,
+    to_number,
+    medium,
+    agent,
+    status="Ringing",
+    call_type="Incoming",
+):
+    call_log = frappe.new_doc("CRM Call Log")
+    call_log.id = call_id
+    call_log.to = to_number
+    call_log.medium = medium
+    call_log.type = call_type
+    call_log.status = status
+    call_log.telephony_medium = "WebSprix"
+    setattr(call_log, "from", from_number)
+
+    if call_type == "Incoming":
+        call_log.receiver = agent
+    else:
+        call_log.caller = agent
+
+    contact_number = from_number if call_type == "Incoming" else to_number
+    link(contact_number, call_log)
+
+    call_log.save(ignore_permissions=True)
+    frappe.db.commit()
+    return call_log
+
+
+def link(contact_number, call_log):
+    contact = get_contact_by_phone_number(contact_number)
+    if contact.get("name"):
+        doctype = "Contact"
+        docname = contact.get("name")
+        if contact.get("lead"):
+            doctype = "CRM Lead"
+            docname = contact.get("lead")
+        elif contact.get("deal"):
+            doctype = "CRM Deal"
+            docname = contact.get("deal")
+        call_log.link_with_reference_doc(doctype, docname)
+
+
+def get_call_log(call_payload):
+    call_log_id = call_payload.get("call_id")
+    if frappe.db.exists("CRM Call Log", call_log_id):
+        return frappe.get_doc("CRM Call Log", call_log_id)
+
+
+def get_call_log_status(call_payload):
+    status = call_payload.get("status")
+    if status == "completed":
+        return "Completed"
+    elif status == "in-progress":
+        return "In Progress"
+    elif status == "busy":
+        return "Ringing"
+    elif status == "no-answer":
+        return "No Answer"
+    elif status == "failed":
+        return "Failed"
+    return status
+
+
+def update_call_log(call_payload, status="Ringing", call_log=None):
+    call_log = call_log or get_call_log(call_payload)
+    status = get_call_log_status(call_payload)
+    try:
+        if call_log:
+            call_log.status = status
+            call_log.to = call_payload.get("to")
+            call_log.duration = call_payload.get("duration") or 0
+            call_log.recording_url = call_payload.get("recording_url") or ""
+            call_log.start_time = call_payload.get("start_time")
+            call_log.end_time = call_payload.get("end_time")
+            if call_payload.get("agent"):
+                call_log.receiver = call_payload.get("agent")
+            call_log.save(ignore_permissions=True)
+            frappe.db.commit()
+            return call_log
+    except Exception:
+        frappe.log_error(title="Error while updating call record")
+        frappe.db.commit()
+
+
+def validate_request():
+    webhook_verify_token = frappe.db.get_single_value("CRM WebSprix Settings", "webhook_verify_token")
+    key = frappe.request.args.get("key")
+    is_valid = key and key == webhook_verify_token
+
+    if not is_valid:
+        frappe.throw(_("Unauthorized request"), exc=frappe.PermissionError)

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -98,6 +98,7 @@ declare module 'vue' {
     ERPNextSettings: typeof import('./src/components/Settings/ERPNextSettings.vue')['default']
     ErrorPage: typeof import('./src/components/ErrorPage.vue')['default']
     ExotelCallUI: typeof import('./src/components/Telephony/ExotelCallUI.vue')['default']
+    WebSprixCallUI: typeof import('./src/components/Telephony/WebSprixCallUI.vue')['default']
     ExportIcon: typeof import('./src/components/Icons/ExportIcon.vue')['default']
     ExternalLinkIcon: typeof import('./src/components/Icons/ExternalLinkIcon.vue')['default']
     FadedScrollableDiv: typeof import('./src/components/FadedScrollableDiv.vue')['default']

--- a/frontend/src/components/Telephony/WebSprixCallUI.vue
+++ b/frontend/src/components/Telephony/WebSprixCallUI.vue
@@ -1,0 +1,15 @@
+<template>
+  <div v-show="false" />
+</template>
+<script setup>
+const props = defineProps({})
+
+function makeOutgoingCall(number) {
+  // placeholder for WebSprix outbound call
+  console.log('Calling via WebSprix', number)
+}
+
+function setup() {}
+
+defineExpose({ makeOutgoingCall, setup })
+</script>

--- a/frontend/src/composables/settings.js
+++ b/frontend/src/composables/settings.js
@@ -24,6 +24,7 @@ export const callEnabled = ref(false)
 export const twilioEnabled = ref(false)
 export const exotelEnabled = ref(false)
 export const plivoEnabled = ref(false)
+export const websprixEnabled = ref(false)
 export const defaultCallingMedium = ref('')
 createResource({
   url: 'crm.integrations.api.is_call_integration_enabled',
@@ -33,8 +34,13 @@ createResource({
     twilioEnabled.value = Boolean(data.twilio_enabled)
     exotelEnabled.value = Boolean(data.exotel_enabled)
     plivoEnabled.value = Boolean(data.plivo_enabled)
+    websprixEnabled.value = Boolean(data.websprix_enabled)
     defaultCallingMedium.value = data.default_calling_medium
-    callEnabled.value = twilioEnabled.value || exotelEnabled.value || plivoEnabled.value
+    callEnabled.value =
+      twilioEnabled.value ||
+      exotelEnabled.value ||
+      plivoEnabled.value ||
+      websprixEnabled.value
   },
 })
 


### PR DESCRIPTION
## Summary
- integrate WebSprix server handler
- expose WebSprix settings doctype
- support WebSprix from Vue settings panel and call UI
- add placeholder WebSprix call component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*
- `ruff check .` *(fails: Found 34 errors)*