### PR TITLE
Update WebSprix settings

### DIFF
--- a/crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
+++ b/crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
@@ -20,6 +20,7 @@
     "exotel_number",
     "websprix",
     "websprix_number",
+    "websprix_queue_id",
     "section_break_phlq",
     "phone_nos"
   ],
@@ -66,6 +67,13 @@
       "fieldname": "websprix_number",
       "fieldtype": "Data",
       "label": "WebSprix Number",
+      "mandatory_depends_on": "websprix"
+    },
+    {
+      "depends_on": "websprix",
+      "fieldname": "websprix_queue_id",
+      "fieldtype": "Data",
+      "label": "Queue ID",
       "mandatory_depends_on": "websprix"
     },
     {

--- a/crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.json
+++ b/crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.json
@@ -9,59 +9,33 @@
 		"column_break_a",
 		"record_call",
 		"section_break_a",
-		"auth_id",
-		"column_break_b",
-		"auth_token",
-		"section_break_b",
-		"webhook_verify_token",
-		"column_break_c",
-		"organization_id",
-		"api_key"
-	],
+                "customer_id",
+                "column_break_c",
+                "organization_id",
+                "api_key"
+        ],
 	"fields": [
 		{"default": "0", "fieldname": "enabled", "fieldtype": "Check", "label": "Enabled"},
 		{"fieldname": "section_break_a", "fieldtype": "Section Break", "hide_border": 1},
-		{
-			"depends_on": "enabled",
-			"fieldname": "auth_id",
-			"fieldtype": "Data",
-			"label": "Auth ID",
-			"mandatory_depends_on": "enabled"
-		},
-		{
-			"depends_on": "enabled",
-			"fieldname": "section_break_b",
-			"fieldtype": "Section Break",
-			"hide_border": 1
-		},
-		{"fieldname": "column_break_b", "fieldtype": "Column Break"},
-		{
-			"depends_on": "enabled",
-			"fieldname": "auth_token",
-			"fieldtype": "Password",
-			"in_list_view": 1,
-			"label": "Auth Token",
-			"mandatory_depends_on": "enabled"
-		},
-		{"fieldname": "column_break_a", "fieldtype": "Column Break"},
-		{
-			"default": "0",
-			"depends_on": "enabled",
-			"fieldname": "record_call",
-			"fieldtype": "Check",
-			"label": "Record Outgoing Calls"
-		},
-		{
-			"depends_on": "enabled",
-			"fieldname": "webhook_verify_token",
-			"fieldtype": "Data",
-			"label": "Webhook Verify Token",
-			"mandatory_depends_on": "enabled"
-		},
-		{"fieldname": "column_break_c", "fieldtype": "Column Break"},
-		{
-			"depends_on": "enabled",
-			"fieldname": "organization_id",
+                {"fieldname": "column_break_a", "fieldtype": "Column Break"},
+                {
+                        "default": "0",
+                        "depends_on": "enabled",
+                        "fieldname": "record_call",
+                        "fieldtype": "Check",
+                        "label": "Record Outgoing Calls"
+                },
+                {
+                        "depends_on": "enabled",
+                        "fieldname": "customer_id",
+                        "fieldtype": "Data",
+                        "label": "Customer ID",
+                        "mandatory_depends_on": "enabled"
+                },
+                {"fieldname": "column_break_c", "fieldtype": "Column Break"},
+                {
+                        "depends_on": "enabled",
+                        "fieldname": "organization_id",
 			"fieldtype": "Data",
 			"label": "Organization ID",
 			"mandatory_depends_on": "enabled"

--- a/crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.py
+++ b/crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.py
@@ -5,26 +5,15 @@ from frappe.model.document import Document
 
 
 class CRMWebSprixSettings(Document):
-	def validate(self):
-		self.verify_credentials()
+    def validate(self) -> None:
+        self.verify_credentials()
 
-	def verify_credentials(self):
-		if self.enabled:
-			response = requests.get(
-				f"https://etw-pbx-cloud1.websprix.com/api/v1/Account/{self.auth_id}/",
-				auth=(self.auth_id, self.get_password("auth_token")),
-			)
-			if response.status_code != 200:
-				frappe.throw(
-					_(f"Please enter valid WebSprix Auth ID & Auth Token: {response.reason}"),
-					title=_("Invalid credentials"),
-				)
-
-			if self.organization_id and self.api_key:
-				verify_url = (
-					f"https://etw-pbx-cloud1.websprix.com/api/v2/cust_ext/{self.organization_id}/cust"
-				)
-				headers = {"x-api-key": self.api_key}
-				res = requests.get(verify_url, headers=headers)
-				if res.status_code not in [200, 201]:
-					frappe.throw(_("Invalid WebSprix Organization ID or API Key"))
+    def verify_credentials(self) -> None:
+        if self.enabled and self.organization_id and self.api_key:
+            verify_url = (
+                f"https://etw-pbx-cloud1.websprix.com/api/v2/cust_ext/{self.organization_id}/cust"
+            )
+            headers = {"x-api-key": self.api_key}
+            res = requests.get(verify_url, headers=headers)
+            if res.status_code not in [200, 201]:
+                frappe.throw(_("Invalid WebSprix Organization ID or API Key"))

--- a/crm/integrations/websprix/handler.py
+++ b/crm/integrations/websprix/handler.py
@@ -75,10 +75,11 @@ def make_a_call(to_number, from_number=None, caller_id=None):
 
     record_call = frappe.db.get_single_value("CRM WebSprix Settings", "record_call")
 
+    headers = {"x-api-key": get_websprix_settings().api_key}
     try:
         response = requests.post(
             endpoint,
-            auth=(get_websprix_settings().auth_id, get_websprix_settings().get_password("auth_token")),
+            headers=headers,
             data={
                 "from": caller_id or from_number,
                 "to": to_number,
@@ -109,7 +110,7 @@ def make_a_call(to_number, from_number=None, caller_id=None):
 def get_websprix_endpoint(action=None, version="v1"):
     settings = get_websprix_settings()
     base = (
-        f"https://etw-pbx-cloud1.websprix.com/api/{version}/Account/{settings.auth_id}/"
+        f"https://etw-pbx-cloud1.websprix.com/api/{version}/Account/{settings.customer_id}/"
     )
     if action:
         base += action
@@ -118,9 +119,7 @@ def get_websprix_endpoint(action=None, version="v1"):
 
 def get_status_updater_url():
     from frappe.utils.data import get_url
-
-    webhook_verify_token = frappe.db.get_single_value("CRM WebSprix Settings", "webhook_verify_token")
-    return get_url(f"api/method/crm.integrations.websprix.handler.handle_request?key={webhook_verify_token}")
+    return get_url("api/method/crm.integrations.websprix.handler.handle_request")
 
 
 def get_websprix_settings():
@@ -128,12 +127,7 @@ def get_websprix_settings():
 
 
 def validate_request():
-    webhook_verify_token = frappe.db.get_single_value("CRM WebSprix Settings", "webhook_verify_token")
-    key = frappe.request.args.get("key")
-    is_valid = key and key == webhook_verify_token
-
-    if not is_valid:
-        frappe.throw(_("Unauthorized request"), exc=frappe.PermissionError)
+    pass
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- add Queue ID to Telephony Agent
- adjust WebSprix settings fields
- update WebSprix settings validation
- update WebSprix call handler to use API key

## Testing
- `ruff check crm/fcrm/doctype/crm_websprix_settings/crm_websprix_settings.py`
- `pytest -k "crm_websprix_settings"` *(fails: ModuleNotFoundError: No module named 'frappe')*